### PR TITLE
bugfix: improved platform package specification in examples

### DIFF
--- a/examples/IMU/platformio.ini
+++ b/examples/IMU/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitm-1]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32-s3-devkitm-1
 framework = arduino
 lib_deps = stm32duino/STM32duino LSM6DSO32@^1.0.0

--- a/examples/KalmanFilter/platformio.ini
+++ b/examples/KalmanFilter/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32dev
 framework = arduino
 monitor_speed = 115200

--- a/examples/LoRa/platformio.ini
+++ b/examples/LoRa/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitm-1]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32-s3-devkitm-1
 framework = arduino
 lib_deps = 

--- a/examples/LoRa_test_ricezione/platformio.ini
+++ b/examples/LoRa_test_ricezione/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitm-1]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32-s3-devkitm-1
 framework = arduino
 lib_deps = 

--- a/examples/altimetro/platformio.ini
+++ b/examples/altimetro/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32dev
 framework = arduino 
 

--- a/examples/blinker/platformio.ini
+++ b/examples/blinker/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitc-1]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32-s3-devkitc-1
 framework = arduino
 

--- a/examples/helloworld/platformio.ini
+++ b/examples/helloworld/platformio.ini
@@ -9,6 +9,6 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitc-1]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32-s3-devkitc-1
 framework = arduino

--- a/examples/logger/platformio.ini
+++ b/examples/logger/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32-s3-devkitc-1]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32-s3-devkitc-1
 framework = arduino
 monitor_filters = esp32_exception_decoder

--- a/examples/sdcard/platformio.ini
+++ b/examples/sdcard/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-platform = espressif32
+platform = platformio/espressif32@^7.0.1
 board = esp32-s3-devkitc-1
 framework = arduino
 build_flags =


### PR DESCRIPTION
Improved platform package spec inside of `platformio.ini` for all examples, to improve compatibility between examples that use vanilla platformio and ones that use [pioarduino](https://github.com/pioarduino/platform-espressif32) (community fork).
Mainly:

```ini
; Before
[env]
platform = espressif32
```

```ini
; After
[env]
platform = platformio/espressif32@^7.0.1
```